### PR TITLE
Manually specify bevy features, remove audio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,39 @@ readme = "README.md"
 exclude = ["assets/*"]
 
 [dependencies]
-bevy = "0.15"
+bevy = { version = "0.15", default-features = false, features = [
+    "android-game-activity",
+    "animation",
+    "bevy_asset",
+    "bevy_color",
+    "bevy_core_pipeline",
+    "bevy_gilrs",
+    "bevy_gizmos",
+    "bevy_gltf",
+    "bevy_mesh_picking_backend",
+    "bevy_pbr",
+    "bevy_picking",
+    "bevy_render",
+    "bevy_scene",
+    "bevy_sprite",
+    "bevy_sprite_picking_backend",
+    "bevy_state",
+    "bevy_text",
+    "bevy_ui",
+    "bevy_ui_picking_backend",
+    "bevy_window",
+    "bevy_winit",
+    "custom_cursor",
+    "default_font",
+    "hdr",
+    "multi_threaded",
+    "png",
+    "smaa_luts",
+    "sysinfo_plugin",
+    "tonemapping_luts",
+    "webgl2",
+    "x11",
+]}
 image = "0.25"
 thiserror = "1.0.62"
 


### PR DESCRIPTION
I lost a lot of my sanity trying to figure out why I could not disable bevy's default features, and I traced the problem to this crate.
I have disabled the default features and instead manually specified them, but I removed `bevy_audio`, which is not needed.
There might be other 'useless' features, but that was the only one I needed to remove.